### PR TITLE
Fix direction semantics in paradigm-rfq-trader + add evals

### DIFF
--- a/skills/paradigm-rfq-trader/SKILL.md
+++ b/skills/paradigm-rfq-trader/SKILL.md
@@ -30,7 +30,7 @@ compatibility: >
   channel — plain text everywhere else.
 metadata:
   author: tradeparadex
-  version: "5.2"
+  version: "5.3"
 ---
 
 # Paradigm RFQ Trader
@@ -165,7 +165,7 @@ ambiguous, ask.
 | Field | Meaning |
 |---|---|
 | `venue` | `PRDX` or `DBT` (see scope table; ask if unspecified) |
-| `legs` | `{instrument_id, ratio, side, price?}` rows. Outright = 1 leg; spread / straddle / RR = 2 legs; condors etc. = more |
+| `legs` | `{instrument_id, ratio, side, price?}` rows. Outright = 1 leg; spread / straddle / RR = 2 legs; condors etc. = more. `side` defines structure orientation — see **Direction** below |
 | `quantity` | Decimal string in base units |
 | `counterparties` | **Default: reach every LP that supports the venue.** Send an empty / omitted list → Paradigm broadcasts the RFQ (open / GRFQ) to all eligible makers. Only narrow to specific desk names (from `paradigm_drfqv2_counterparties`) when the user names them. Fallback: if a bare broadcast does not fan out to all venue LPs, resolve the full desk list and pass it explicitly (see Step 3a · 1) |
 | `is_taker_anonymous` | Hide identity from makers (optional) |
@@ -181,6 +181,32 @@ ambiguous, ask.
 | `quantity` | Defaults to RFQ quantity |
 | `type` | `LIMIT` (default) or `HIDDEN` |
 | `time_in_force` | `GOOD_TILL_CANCELED` (rest) or `FILL_OR_KILL` (cross) |
+
+### Direction — read before building `legs`
+
+Leg `side` values define the *structure*; the package you submit defines
+the *direction you hold it*. To go **long** a structure, configure the
+leg sides so the package IS the position the user wants and submit it as
+a **BUY** (positive quantity). Do **not** also flip every leg to a
+"short" orientation and then SELL — that double-negates back to long
+(the common bug).
+
+Use **SELL on the package only** when you built a *conventional /
+textbook* structure and the user wants its inverse — e.g. "short call
+spread" = build the conventional debit call spread (BUY lower call +
+SELL higher call), then SELL the package.
+
+- Bullish call spread → BUY lower-strike call + SELL higher-strike call,
+  submit **BUY**. "Short call spread" → same legs, submit **SELL**.
+- Bearish put spread → BUY higher-strike put + SELL lower-strike put,
+  submit **BUY**.
+- Bullish risk reversal (e.g. 90/80) → BUY 90 call + SELL 80 put, submit
+  **BUY**. Bearish → SELL call + BUY put in the legs, submit **BUY**.
+- **Outright** (1 leg) → no structure to orient: short = a single leg
+  `side=SELL`; don't also flip a package direction.
+
+The cross `side` at `post_order` (Step 3a · 5) is a separate
+matching-mechanics concern — see there.
 
 If anything is ambiguous, ask before calling tools.
 
@@ -226,7 +252,10 @@ for the session; do not invent IDs.
 5. **Cross** — `paradigm_drfqv2_post_order(rfq_id=..., side=...,
    type="LIMIT", time_in_force="FILL_OR_KILL", price=..., quantity=...,
    legs=[...])`. `side` is opposite the resting order being taken.
-   Response is async-first (`state: OrderState.PENDING`) — poll
+   This cross `side` is matching mechanics (lift an offer = BUY, hit a
+   bid = SELL) and is independent of the structure's long/short
+   orientation, which the leg sides already fixed at create-time (see
+   Direction). Response is async-first (`state: OrderState.PENDING`) — poll
    `paradigm_drfqv2_orders` for the transition to `CLOSED`. Surface
    `trade_id` from `paradigm_drfqv2_trades(rfq_id=...)` once cleared,
    then follow the venue's settlement-check recipe in
@@ -281,6 +310,9 @@ Fair: mid $96,455 · BBO 96,450/96,460 (10 bps) · walk 500 ~$96,612 (+16 bps)
 
 Keep it to this shape — header line, action line + notional, one
 fair-value line, prompt. Don't restate fields the user already gave.
+For multi-leg structures, the action line states the **net** direction
+the taker will hold (long / short the structure), confirmed against
+**Direction** (Step 1) — not merely a restatement of leg sides.
 
 For options or for Deribit, the **structure of the block is the
 same** — header line, leg(s) listed, fair-value reference, sizing

--- a/skills/paradigm-rfq-trader/evals/evals.json
+++ b/skills/paradigm-rfq-trader/evals/evals.json
@@ -158,9 +158,51 @@
         "Response benchmarks against a Paradex fair-value source (paradex_bbo / paradex_orderbook) for the offset",
         "Response does NOT auto-cross or place an order without explicit user confirmation; it keeps streaming until the user crosses, cancels, or the RFQ expires"
       ]
+    },
+    {
+      "id": 14,
+      "prompt": "send a bearish BTC 8MAY26 risk reversal on Paradex — short the 90000 call, long the 80000 put — 100 contracts, to LP1 and LP2",
+      "expected_output": "A taker option RFQ flow that expresses the user's desired (bearish) exposure directly in the leg sides and then BUYS the configured package, rather than flipping the legs to a 'short' orientation AND submitting a SELL (which would double-negate back to long). The flow: (1) resolves both option ids via paradigm_drfqv2_instruments(venue=\"PRDX\", venue_instrument_name=\"BTC-USD-8MAY26-90000-C\") and the matching 80000-P; (2) configures legs to encode the stated exposure — SELL the 90000 call, BUY the 80000 put; (3) pulls paradex_market_summaries per option (mark_price, mark_iv, delta, vega) and BTC-USD-PERP for spot; (4) aggregates net structure mark + net delta + net vega; (5) presents a confirmation block whose net direction reads as short/bearish the structure (not a restatement of leg sides) and waits for explicit yes before invoking paradigm_drfqv2_create_rfq with venue=PRDX, two legs, quantity=100, counterparties=[\"LP1\",\"LP2\"] — submitted as a BUY of the configured package.",
+      "assertions": [
+        "Response resolves BOTH option instrument_ids via paradigm_drfqv2_instruments with venue=PRDX",
+        "Response encodes the bearish exposure in the leg sides — SELL the 90000 call and BUY the 80000 put",
+        "Response submits the configured package as a BUY (positive quantity 100), NOT as a SELL",
+        "Response does NOT both invert every leg to a short orientation AND submit a SELL (no double-negation back to long)",
+        "Response pulls paradex_market_summaries per leg plus BTC-USD-PERP spot for fair-value reference",
+        "Response presents a confirmation block whose net direction reads as short/bearish the structure and waits for explicit yes before invoking paradigm_drfqv2_create_rfq"
+      ]
+    },
+    {
+      "id": 15,
+      "prompt": "short a BTC 8MAY26 90000/95000 call spread on Paradex, 100 contracts, LP1 and LP2",
+      "expected_output": "A taker option RFQ flow that handles a CONVENTIONAL structure the user wants to short: it builds the textbook (debit / long) call spread orientation in the legs and then submits the package as a SELL to be short it — it does NOT invert the leg sides AND sell (that would double-negate back to long the call spread). The flow: (1) resolves both option ids via paradigm_drfqv2_instruments(venue=\"PRDX\", venue_instrument_name=\"BTC-USD-8MAY26-90000-C\") and the 95000-C; (2) configures the conventional debit call spread — BUY the 90000 call (lower strike) + SELL the 95000 call (higher strike); (3) pulls paradex_market_summaries per leg + BTC-USD-PERP spot; (4) aggregates net structure mark + greeks; (5) presents a confirmation block whose net direction reads as short the call spread and waits for explicit yes before invoking paradigm_drfqv2_create_rfq with venue=PRDX, two legs, quantity=100, counterparties=[\"LP1\",\"LP2\"] — submitted as a SELL of the conventional package.",
+      "assertions": [
+        "Response resolves BOTH option instrument_ids via paradigm_drfqv2_instruments with venue=PRDX (90000-C and 95000-C)",
+        "Response builds the conventional debit call spread in the legs — BUY the lower-strike 90000 call and SELL the higher-strike 95000 call",
+        "Response submits the package as a SELL to be short the conventional call spread (quantity 100)",
+        "Response does NOT invert the leg sides AND submit a SELL (no double-negation back to long the call spread)",
+        "Response pulls paradex_market_summaries per leg plus BTC-USD-PERP spot for fair-value reference",
+        "Response presents a confirmation block whose net direction reads as short the call spread and waits for explicit yes before invoking paradigm_drfqv2_create_rfq"
+      ]
+    },
+    {
+      "id": 16,
+      "prompt": "send a Paradigm block RFQ to sell 500 BTC perp on Paradex",
+      "expected_output": "A taker RFQ-build flow for a short OUTRIGHT perp, where 'short' is simply a single leg with side=SELL — there is no structure to configure-then-buy, so the skill must NOT add any extra package-direction flip. The flow: (1) resolves the instrument_id via paradigm_drfqv2_instruments(venue=\"PRDX\", venue_instrument_name=\"BTC-USD-PERP\"); (2) assembles a paradigm_drfqv2_create_rfq call with venue=PRDX, a single leg (ratio=1, side=SELL), quantity=500, and counterparties left EMPTY/OMITTED so the RFQ broadcasts to all PRDX LPs (the user named no desks); (3) pulls Paradex BBO + orderbook via paradex_bbo / paradex_orderbook for fair-value reference and the walked-bid proceeds for 500 BTC; (4) presents a confirmation block (action line: SELL 500 BTC, counterparties as broadcast to all PRDX LPs) and waits for explicit yes; (5) includes a data-source trace.",
+      "assertions": [
+        "Response resolves the instrument via paradigm_drfqv2_instruments with venue=PRDX and venue_instrument_name=BTC-USD-PERP",
+        "Response assembles a paradigm_drfqv2_create_rfq call with a SINGLE leg, side=SELL, quantity=500",
+        "Response does NOT apply any spurious structure inversion or extra package-direction flip — short outright is just one SELL leg",
+        "Because the user named no desks, the create_rfq reaches ALL PRDX LPs (empty/omitted counterparties broadcast) rather than a hard-coded subset",
+        "Response pulls Paradex book data via paradex_bbo or paradex_orderbook for fair-value reference",
+        "Response presents a confirmation block and waits for explicit yes before invoking paradigm_drfqv2_create_rfq"
+      ]
     }
   ],
   "trigger_evals": [
+    {"query": "send a bearish BTC 8MAY26 risk reversal on Paradex, short the call long the put", "should_trigger": true},
+    {"query": "short a BTC 8MAY26 90000/95000 call spread on Paradex, 100 contracts", "should_trigger": true},
+    {"query": "send a Paradigm block RFQ to sell 500 BTC perp on Paradex", "should_trigger": true},
     {"query": "send a Paradex block RFQ for 500 BTC perp", "should_trigger": true},
     {"query": "source liquidity for an ETH-USD-PERP block, 200 ETH", "should_trigger": true},
     {"query": "quote rfq_12345 at 2 bps over the Paradex mid", "should_trigger": true},


### PR DESCRIPTION
When a user asks to be short a structure, the skill previously could
flip every leg to a short orientation AND submit a SELL — two negations
that cancel out, landing on the opposite (long) position. SKILL.md gave
no guidance on translating long/short intent into leg sides + package
direction.

Add a "Direction" subsection to Step 1: configure leg sides so the
package IS the desired position, then BUY it. Reserve SELL for a
conventional/textbook structure the user wants inverted (e.g. "short
call spread" = build the debit call spread, then SELL). Cross-reference
the legs table, the Step 3a cross step (separates structure orientation
from cross matching mechanics), and the Step 4 confirmation gate (net
direction, not a restatement of leg sides). Bump version 5.2 -> 5.3.

Add evals 14 (bearish risk reversal -> configure-then-BUY), 15 ("short
call spread" -> conventional -> SELL), 16 (outright short perp regression
guard), plus matching trigger_evals.

https://claude.ai/code/session_01TVXHu8cLh6h99j3mWb3gJP