### PR TITLE
ci: add Claude on Bedrock workflow (OIDC)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,48 @@
+name: Claude
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write      # mandatory for OIDC — omitting causes silent auth failure
+      contents: write
+      pull-requests: write
+      issues: write
+      actions: read        # lets Claude read CI results on PRs
+    steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Configure AWS credentials (Bedrock via OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: eu-west-2
+
+      - name: Run Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          model: eu.anthropic.claude-opus-4-8
+          use_bedrock: "true"
+          github_token: ${{ steps.app-token.outputs.token }}
+          additional_permissions: |
+            actions: read

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -92,5 +92,5 @@ jobs:
       - name: Run full evals (Claude on Bedrock)
         run: |
           uv run run_evals.py --simulate --fail-below 0.8 \
-            --agent-model eu.anthropic.claude-opus-4-8 \
+            --agent-model eu.anthropic.claude-sonnet-4-6 \
             --grader-model eu.anthropic.claude-opus-4-8

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -96,7 +96,14 @@ jobs:
           aws-region: eu-west-2
 
       - name: Run full evals (Claude on Bedrock)
+        env:
+          PYTHONUNBUFFERED: "1"   # flush progress lines immediately (no TTY in CI)
         run: |
-          uv run run_evals.py --simulate --fail-below 0.8 \
+          # Run `python run_evals.py` (not `uv run run_evals.py`) so uv does NOT
+          # install the script's local-model deps (llama-cpp-python compiles from
+          # source here — minutes of silent build). The Bedrock path only needs
+          # anthropic[bedrock]; -v prints per-assertion detail for progress.
+          uv run --with 'anthropic[bedrock]' python run_evals.py \
+            --simulate --fail-below 0.8 -v \
             --agent-model eu.anthropic.claude-sonnet-4-6 \
             --grader-model eu.anthropic.claude-opus-4-8

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel an in-progress run when a newer commit is pushed to the same branch/PR.
+# Grouped by workflow + ref so push-to-main and each PR get independent lanes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/.github/workflows/evals.yml
+++ b/.github/workflows/evals.yml
@@ -75,16 +75,22 @@ jobs:
   evals:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    permissions:
+      id-token: write   # mandatory for OIDC — omitting causes silent auth failure
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
       - uses: astral-sh/setup-uv@v5
 
-      - name: Restore model cache
-        uses: actions/cache@v4
+      - name: Configure AWS credentials (Bedrock via OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          path: ~/.cache/huggingface
-          key: hf-gemma-3-1b-it-Q4_K_M-v1
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          aws-region: eu-west-2
 
-      - name: Run full evals (local model)
-        run: uv run run_evals.py --local --simulate --fail-below 0.8
+      - name: Run full evals (Claude on Bedrock)
+        run: |
+          uv run run_evals.py --simulate --fail-below 0.8 \
+            --agent-model eu.anthropic.claude-opus-4-8 \
+            --grader-model eu.anthropic.claude-opus-4-8

--- a/run_evals.py
+++ b/run_evals.py
@@ -619,10 +619,16 @@ def main() -> None:
             sys.exit(1)
 
         bedrock_token = os.environ.get("AWS_BEARER_TOKEN_BEDROCK")
+        region        = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
+        # OIDC / SSO / static AWS credentials all surface through the standard
+        # boto3 credential chain. In CI, aws-actions/configure-aws-credentials
+        # mints short-lived OIDC credentials and exports AWS_ACCESS_KEY_ID +
+        # AWS_REGION — so a bearer token is not the only way onto Bedrock.
+        aws_creds     = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("AWS_PROFILE")
+        use_bedrock   = bool(bedrock_token or (aws_creds and region))
         api_key       = os.environ.get("ANTHROPIC_API_KEY")
 
-        if bedrock_token:
-            region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
+        if use_bedrock:
             client = anthropic.AnthropicBedrock(aws_region=region) if region else anthropic.AnthropicBedrock()
             if args.agent_model == DEFAULT_AGENT_MODEL:
                 args.agent_model = DEFAULT_BEDROCK_AGENT_MODEL
@@ -631,7 +637,11 @@ def main() -> None:
         elif api_key:
             client = anthropic.Anthropic(api_key=api_key)
         else:
-            print("Error: set ANTHROPIC_API_KEY or AWS_BEARER_TOKEN_BEDROCK", file=sys.stderr)
+            print(
+                "Error: set ANTHROPIC_API_KEY, AWS_BEARER_TOKEN_BEDROCK, or "
+                "AWS credentials together with AWS_REGION",
+                file=sys.stderr,
+            )
             sys.exit(1)
 
     # Resolve skill list


### PR DESCRIPTION
Enables `@claude` via Amazon Bedrock + GitHub OIDC (no static API keys).

- Auth: OIDC -> IAM role `github-claude-bedrock` (acct 654650380203), Bedrock in eu-west-2, model `eu.anthropic.claude-opus-4-8`.
- Uses org secrets `AWS_ROLE_TO_ASSUME`, `APP_ID`, `APP_PRIVATE_KEY` (already set at org level, visibility=all).
- **Depends on** GitHub App `paradex-claude-bot` (app_id 3938294) being installed on this org. Merge once the app is installed.