### PR TITLE
Add paradex-options-recap skill for market flow analysis

### DIFF
--- a/skills/options-recap/SKILL.md
+++ b/skills/options-recap/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: paradex-options-recap
+description: >
+  Market recap for crypto options flow over a user-specified time window, invoked
+  via /recap. Parses the command syntax "/recap [asset] [options|perps|all] [window]"
+  (e.g. "/recap btc options 8h", "/recap eth options 24h", "/recap btc options 1d").
+  Produces: DVOL/spot summary, largest block prints with greeks and IV context,
+  screen flow themes, vol surface reads, and a net bias call. Use when the user
+  types /recap or asks for a market recap, options flow summary, vol surface snapshot,
+  "what happened in BTC options", "give me the last Xh of flow", "what's been trading",
+  or any broad options market summary question. Distinct from paradigm-block-analyst
+  (single trade deep-dive) and paradex-market-analyst (Paradex perp technicals) —
+  this skill is about the OPTIONS MARKET as a whole over a period, not a single trade.
+compatibility: Uses Deribit public API (web_fetch), Paradigm block tape (if injected),
+  and deribit__get_ticker MCP (if available). No authentication required.
+metadata:
+  author: tradeparadex
+  version: "1.0"
+---
+
+# Options Recap
+
+Turns raw options flow — block prints, screen activity, and vol surface data — into
+a concise market recap for a user-specified window. Answers "what happened in the options
+market over the last N hours?" with facts: DVOL, spot range, block structures, screen themes,
+and a surface read.
+
+## Trigger — Command Syntax
+
+Fire when the user types `/recap` or a close paraphrase. Parse the command as:
+
+```
+/recap [asset] [market_type] [window]
+```
+
+| Token | Examples | Default |
+|---|---|---|
+| `asset` | `btc`, `eth`, `sol` | `btc` |
+| `market_type` | `options`, `opts`, `perps`, `all` | `options` |
+| `window` | `1h`, `4h`, `8h`, `24h`, `1d`, `2d`, `7d` | `24h` |
+
+**Parsing rules:**
+- Tokens can appear in any order: `/recap 8h btc options` and `/recap btc options 8h` are equivalent.
+- Missing tokens take their defaults: `/recap` alone means BTC options, last 24h.
+- If `market_type` is `perps` or not `options`, note that this skill covers options flow
+  and route the user to `paradex-market-analyst` for perp technicals.
+- Convert window to start/end UTC timestamps (now − window → now).
+
+**Examples:**
+- `/recap` → BTC options, last 24h
+- `/recap btc options 8h` → BTC options, last 8h
+- `/recap eth options 4h` → ETH options, last 4h
+- `/recap btc 1d` → BTC options, last 24h
+
+## Data Sources
+
+Fetch all sources in parallel. Never wait for one before starting the next.
+
+| Source | What to fetch | Endpoint |
+|---|---|---|
+| Deribit DVOL | Index level + history for the window | `GET /api/v2/public/get_tradingview_chart_data?instrument_name=DVOL&resolution=60&start_timestamp=<start_ms>&end_timestamp=<end_ms>` |
+| Deribit spot / futures | Index price history + spot range for the window | `GET /api/v2/public/get_tradingview_chart_data?instrument_name=<ASSET>_USDC&resolution=60` |
+| Deribit block trades | Blocks over the window | `GET /api/v2/public/get_last_trades_by_currency?currency=<BTC/ETH>&kind=option&count=500&start_timestamp=<start_ms>&end_timestamp=<end_ms>&sorting=desc` — filter for `block_trade_id` set |
+| Deribit screen flow | On-screen option trades, large clips | Same endpoint, filter trades WITHOUT `block_trade_id` — take the top ~200 by size for pattern analysis |
+| Vol surface snapshot | Current mark IV for key strikes/expiries | `GET /api/v2/public/get_instruments?currency=<BTC/ETH>&kind=option&expired=false` then `deribit__get_ticker` or `web_fetch /api/v2/public/ticker?instrument_name=<inst>` for near-dated ATM and key strikes |
+| Paradigm block tape | If injected in session — block structs, size, direction | Already parsed (no fetch needed) |
+
+**If `deribit__get_ticker` MCP is available**, prefer it for vol surface fetches (faster than web_fetch).
+
+## Step 1 — DVOL and Spot
+
+From DVOL history:
+- `dvol_start` = DVOL at window open
+- `dvol_end` = DVOL now
+- `dvol_range` = min–max across window
+- `dvol_delta` = end − start (vol sold through / bought through)
+
+From spot / futures:
+- `spot_start`, `spot_end`, `spot_low`, `spot_high` for the window
+- `spot_change_pct` = (end − start) / start × 100
+- Nearest front-month futures: fetch `paradex_market_summaries` or Deribit futures summary
+  for 24h volume if available
+
+**Spot vs vol relationship:** label it factually:
+- Spot up + vol down → "vol sold through a rally"
+- Spot down + vol up → "vol bid into weakness"
+- Spot up + vol up → "vol bought through a rally" (fear bid or demand)
+- Spot flat + vol up/down → "vol moved independently of spot"
+
+## Step 2 — Block Flow Analysis
+
+From the Deribit tape, isolate block trades (`block_trade_id` present). For Paradigm-routed
+blocks, they appear here with multi-leg `block_trade_leg_count` > 1.
+
+**Cluster by `block_trade_id`** to reconstruct multi-leg structures. Do not report legs individually
+when they share a block ID — report the reconstructed structure.
+
+For each significant block cluster (threshold: > 10 BTC notional, or any multi-leg structure):
+
+| Field | Derivation |
+|---|---|
+| Time UTC | `timestamp` → HH:MM UTC |
+| Structure | Reconstruct from leg instruments: type (call/put/spread/straddle/calendar/ratio), strikes, expiry(s) |
+| Size | Total contracts (sum of one leg for spreads, use the common ratio) |
+| Side | Buyer (paid debit) or Seller (took credit) — from net premium direction |
+| Level | Fill price in BTC or vol units as appropriate |
+| IV | Per-leg mark IV from the Deribit trade's `iv` field — show both legs for spreads |
+
+**Structure classification from instrument names:**
+- Same expiry, same strike, C+P = Straddle
+- Same expiry, different strikes, same type = Spread (call spread / put spread)
+- Different expiries, same strike, same type = Calendar
+- Put + Call same expiry, different strikes, net delta trade = Risk Reversal or Strangle
+- Single leg = Outright
+
+**Size grouping for the block table:**
+List blocks from largest to smallest. Cap the table at the 8 most significant clusters —
+summarise smaller flow in one prose line ("several 1–5x clips in near-dated OTM calls/puts, mixed flow").
+
+**Two-way vs one-sided read:**
+If the same structure prints on both sides within the window (buyer then seller or vice versa),
+call it "two-way flow" — not accumulation. If only one side, note it.
+
+## Step 3 — Screen Flow Themes
+
+From on-screen (non-block) trades, identify recurring patterns. Group by:
+
+1. **Expiry cluster** — which expiries are active (0DTE, weekly, monthly, quarterly)?
+2. **Strike cluster** — which strikes are repeatedly printing?
+3. **Direction cluster** — consistent put buying vs put selling, call buying vs call selling?
+4. **Size pattern** — small retail clips vs medium institutional?
+5. **IV vs ATM** — strikes printing above or below ATM vol → skew direction
+
+Surface 3–5 themes, each stated as one factual bullet:
+
+```
+- 0DTE / near-dated put bid: <strike> P trading <Xv> vs ATM <Yv> · <n> clips
+- OTM call selling: <strike> C sold <Xv> · <n> clips · [sizes]
+- [Large single print]: <size>x <structure> @ <price> / <IV>v — largest screen print
+- Put selling / premium collection: <strikes> P sold <Xv> on <n>–<m> DTE
+- Tail buying: <strike> P/C @ <price> / <IV>v · <n>x
+```
+
+Keep each bullet to one line. No trailing commentary about what it implies.
+
+## Step 4 — Vol Surface Read
+
+Pull the current vol surface for the main near-dated expiry (and second expiry if calendar flow
+was present). For each expiry, fetch a representative strike grid — at minimum: 10-delta put,
+25-delta put, ATM, 25-delta call, 10-delta call.
+
+Report:
+- **ATM vol** for each active expiry
+- **Put/call skew** (25d put IV minus 25d call IV — positive = puts richer)
+- **Term structure** (near ATM vs back ATM — contango = backwardation in vol)
+- **Notable level** (any strike where mark IV is unusually elevated or compressed vs the rest)
+
+Surface read format:
+
+```
+Near-dated put skew elevated/flat/inverted: <25d P> vs <25d C> = <diff>v put premium
+Term structure: near <Xv> / back <Yv> — [contango / backwardation / flat]
+ATM vol by expiry: <DDMMMYY> <Xv> · <DDMMMYY> <Yv> · ...
+[Notable]: <specific strike/expiry IV anomaly — one line max>
+```
+
+## Step 5 — Output Format
+
+**Your ENTIRE response is the recap block below — match its shape exactly.** Nothing before the
+header, nothing after the bias line. Work silently — no narration, no "fetching…", no tool-call
+commentary. Your single visible message is the recap.
+
+**Formatting rules for terminal rendering:**
+1. Use `##` markdown headers for each section — they render as clear separators.
+2. Use `**bold**` for inline emphasis (DVOL levels, key sizes, bias verdict).
+3. Tables render correctly — use them for block flow and surface reads.
+4. Backtick-wrap section labels that are meant to stand out: `` `[Bias]` ``.
+5. No triple-backtick code fences around the whole output — it renders as a grey box.
+
+---
+
+### Output shape:
+
+```
+## [ASSET] Options — Last [WINDOW] Recap ([START_UTC]–[END_UTC])
+
+### DVOL / Spot
+[ASSET]DVOL [window]: [start]v → [end]v ([+/-delta]v) · range [low]–[high] · [notable spike/dip description if any]
+Spot [window]: low [low] / high [high] / now [price] · [front-month futures]: $[vol]M vol
+[Spot vs vol relationship label]
+
+### Largest Blocks (Paradigm/DBT)
+
+| Time UTC | Structure | Size | Side | Level | IV |
+|---|---|---|---|---|---|
+| [HH:MM] | [structure description] | [N]x | Buy/Sell | [price/level] | [Xv / Yv] |
+...
+
+[Two-way / one-sided flow commentary — one line per distinct flow cluster]
+
+### Screen Flow — Notable Themes
+- [Theme 1]
+- [Theme 2]
+- [Theme 3]
+- [Theme 4 if present]
+- [Theme 5 if present]
+
+### Vol Surface Reads
+[Surface read — 3–5 lines following the format from Step 4]
+
+`[Bias]` [2–4 sentence net bias call: who is in control (vol sellers / vol buyers), which expiry/skew is bid, what the dominant institutional flow was, and what the surface says about near-term positioning. Factual — state what the data shows, not what the user should do.]
+```
+
+---
+
+**The `[Bias]` line is mandatory** — it is the synthesis the recap exists to deliver. State:
+1. Who is in control (vol sellers / vol buyers / neutral)
+2. What the biggest institutional block flow expressed
+3. What the screen theme says about positioning
+4. What the surface (skew, term structure) confirms or contradicts
+
+Keep it to 2–4 sentences. Never recommend a trade. State the market's revealed positioning and let the reader decide.
+
+## Empty / Thin Window
+
+If the window is short (< 2h) and produces no block prints and < 20 screen trades, say:
+
+```
+## [ASSET] Options — Last [WINDOW] Recap
+
+Light window: no block prints, [N] screen trades. DVOL [X]v → [Y]v. Spot [low]–[high].
+[Any single notable print if present, else: "No notable activity."]
+```
+
+## Caveats
+
+- Block trades on Deribit tagged with `block_trade_id` include Paradigm-routed flow. However,
+  Paradigm tape (structure labels, `strategy_code`, taker direction) is only available when
+  injected into the session — otherwise direction/structure is reconstructed from leg signs.
+- IV per trade comes from Deribit's `iv` field on each trade record — this is the mark IV at
+  the moment of the trade, not the transaction-implied IV. It is accurate enough for surface reads.
+- On-screen trade flow is sampled (last ~500 trades). Very thin or very active markets may
+  under- or over-represent screen themes. Treat themes as directional signals, not exhaustive counts.
+- Vol surface snapshot is current (fetch time), not historical. "Elevated put skew" is the
+  state now, which reflects both the window's flow and pre-existing positioning.
+- Not financial advice. This skill describes what the market did — it does not say what to do next.

--- a/skills/options-recap/SKILL.md
+++ b/skills/options-recap/SKILL.md
@@ -1,18 +1,13 @@
 ---
 name: paradex-options-recap
 description: >
-  Market recap for crypto options flow over a user-specified time window, invoked
-  via /recap. Parses the command syntax "/recap [asset] [options|perps|all] [window]"
-  (e.g. "/recap btc options 8h", "/recap eth options 24h", "/recap btc options 1d").
-  Produces: DVOL/spot summary, largest block prints with greeks and IV context,
-  screen flow themes, vol surface reads, and a net bias call. Use when the user
-  types /recap or asks for a market recap, options flow summary, vol surface snapshot,
-  "what happened in BTC options", "give me the last Xh of flow", "what's been trading",
-  or any broad options market summary question. Distinct from paradigm-block-analyst
-  (single trade deep-dive) and paradex-market-analyst (Paradex perp technicals) —
-  this skill is about the OPTIONS MARKET as a whole over a period, not a single trade.
-compatibility: Uses Deribit public API (web_fetch), Paradigm block tape (if injected),
-  and deribit__get_ticker MCP (if available). No authentication required.
+  Options market recap for a user-specified window, invoked via /recap. Parses
+  "/recap [asset] [options] [window]" (e.g. "/recap btc options 8h") and produces:
+  DVOL/spot summary, largest block prints with structure and IV, screen flow themes,
+  vol surface reads, and a net bias call. Use when the user types /recap or asks for
+  a market recap, options flow summary, "what happened in BTC options", or "last Xh of flow".
+compatibility: Deribit public API (web_fetch), Paradigm block tape (if injected),
+  deribit__get_ticker MCP (if available). No authentication required.
 metadata:
   author: tradeparadex
   version: "1.0"
@@ -20,14 +15,9 @@ metadata:
 
 # Options Recap
 
-Turns raw options flow — block prints, screen activity, and vol surface data — into
-a concise market recap for a user-specified window. Answers "what happened in the options
-market over the last N hours?" with facts: DVOL, spot range, block structures, screen themes,
-and a surface read.
+Converts options flow data into a concise market recap for a user-specified window.
 
-## Trigger — Command Syntax
-
-Fire when the user types `/recap` or a close paraphrase. Parse the command as:
+## Command Syntax
 
 ```
 /recap [asset] [market_type] [window]
@@ -35,212 +25,83 @@ Fire when the user types `/recap` or a close paraphrase. Parse the command as:
 
 | Token | Examples | Default |
 |---|---|---|
-| `asset` | `btc`, `eth`, `sol` | `btc` |
-| `market_type` | `options`, `opts`, `perps`, `all` | `options` |
-| `window` | `1h`, `4h`, `8h`, `24h`, `1d`, `2d`, `7d` | `24h` |
+| `asset` | `btc`, `eth` | `btc` |
+| `market_type` | `options`, `opts` | `options` |
+| `window` | `1h`, `4h`, `8h`, `24h`, `1d` | `24h` |
 
-**Parsing rules:**
-- Tokens can appear in any order: `/recap 8h btc options` and `/recap btc options 8h` are equivalent.
-- Missing tokens take their defaults: `/recap` alone means BTC options, last 24h.
-- If `market_type` is `perps` or not `options`, note that this skill covers options flow
-  and route the user to `paradex-market-analyst` for perp technicals.
-- Convert window to start/end UTC timestamps (now − window → now).
+Tokens are order-independent. Missing tokens use defaults. `/recap` alone = BTC options, last 24h.
+If `market_type` is `perps`, route to `paradex-market-analyst` instead.
 
-**Examples:**
-- `/recap` → BTC options, last 24h
-- `/recap btc options 8h` → BTC options, last 8h
-- `/recap eth options 4h` → ETH options, last 4h
-- `/recap btc 1d` → BTC options, last 24h
+## Data Fetches (run in parallel)
 
-## Data Sources
+| Data | Endpoint |
+|---|---|
+| DVOL history | `GET /api/v2/public/get_tradingview_chart_data?instrument_name=BTC_DVOL&resolution=60&start_timestamp=<ms>&end_timestamp=<ms>` |
+| Spot range | Same endpoint, `instrument_name=BTC_USDC` |
+| All option trades | `GET /api/v2/public/get_last_trades_by_currency?currency=BTC&kind=option&count=500&start_timestamp=<ms>&end_timestamp=<ms>&sorting=desc` |
+| Vol surface | `deribit__get_ticker` per key strike, or `web_fetch /api/v2/public/ticker?instrument_name=<inst>` |
 
-Fetch all sources in parallel. Never wait for one before starting the next.
+Filter the trade list: `block_trade_id` present = block; absent = screen flow.
 
-| Source | What to fetch | Endpoint |
-|---|---|---|
-| Deribit DVOL | Index level + history for the window | `GET /api/v2/public/get_tradingview_chart_data?instrument_name=DVOL&resolution=60&start_timestamp=<start_ms>&end_timestamp=<end_ms>` |
-| Deribit spot / futures | Index price history + spot range for the window | `GET /api/v2/public/get_tradingview_chart_data?instrument_name=<ASSET>_USDC&resolution=60` |
-| Deribit block trades | Blocks over the window | `GET /api/v2/public/get_last_trades_by_currency?currency=<BTC/ETH>&kind=option&count=500&start_timestamp=<start_ms>&end_timestamp=<end_ms>&sorting=desc` — filter for `block_trade_id` set |
-| Deribit screen flow | On-screen option trades, large clips | Same endpoint, filter trades WITHOUT `block_trade_id` — take the top ~200 by size for pattern analysis |
-| Vol surface snapshot | Current mark IV for key strikes/expiries | `GET /api/v2/public/get_instruments?currency=<BTC/ETH>&kind=option&expired=false` then `deribit__get_ticker` or `web_fetch /api/v2/public/ticker?instrument_name=<inst>` for near-dated ATM and key strikes |
-| Paradigm block tape | If injected in session — block structs, size, direction | Already parsed (no fetch needed) |
+## Analysis Steps
 
-**If `deribit__get_ticker` MCP is available**, prefer it for vol surface fetches (faster than web_fetch).
-
-## Step 1 — DVOL and Spot
-
-From DVOL history:
-- `dvol_start` = DVOL at window open
-- `dvol_end` = DVOL now
-- `dvol_range` = min–max across window
-- `dvol_delta` = end − start (vol sold through / bought through)
-
-From spot / futures:
-- `spot_start`, `spot_end`, `spot_low`, `spot_high` for the window
-- `spot_change_pct` = (end − start) / start × 100
-- Nearest front-month futures: fetch `paradex_market_summaries` or Deribit futures summary
-  for 24h volume if available
-
-**Spot vs vol relationship:** label it factually:
+**1. DVOL / Spot** — open → close, range, spot low/high. Label the relationship:
 - Spot up + vol down → "vol sold through a rally"
 - Spot down + vol up → "vol bid into weakness"
-- Spot up + vol up → "vol bought through a rally" (fear bid or demand)
-- Spot flat + vol up/down → "vol moved independently of spot"
+- Spot up + vol up → "vol bought through a rally"
 
-## Step 2 — Block Flow Analysis
+**2. Block Flow** — cluster trades by `block_trade_id` to reconstruct multi-leg structures.
+Report top 8 clusters (> 10 BTC notional) in a table: Time · Structure · Size · Side · Level · IV.
+Note two-way vs one-sided flow per structure.
 
-From the Deribit tape, isolate block trades (`block_trade_id` present). For Paradigm-routed
-blocks, they appear here with multi-leg `block_trade_leg_count` > 1.
+Structure types from leg instruments: same expiry + same strike + C+P = Straddle; same expiry + diff strikes + same type = Spread; diff expiries + same strike = Calendar; C+P diff strikes = Strangle/RR.
 
-**Cluster by `block_trade_id`** to reconstruct multi-leg structures. Do not report legs individually
-when they share a block ID — report the reconstructed structure.
-
-For each significant block cluster (threshold: > 10 BTC notional, or any multi-leg structure):
-
-| Field | Derivation |
-|---|---|
-| Time UTC | `timestamp` → HH:MM UTC |
-| Structure | Reconstruct from leg instruments: type (call/put/spread/straddle/calendar/ratio), strikes, expiry(s) |
-| Size | Total contracts (sum of one leg for spreads, use the common ratio) |
-| Side | Buyer (paid debit) or Seller (took credit) — from net premium direction |
-| Level | Fill price in BTC or vol units as appropriate |
-| IV | Per-leg mark IV from the Deribit trade's `iv` field — show both legs for spreads |
-
-**Structure classification from instrument names:**
-- Same expiry, same strike, C+P = Straddle
-- Same expiry, different strikes, same type = Spread (call spread / put spread)
-- Different expiries, same strike, same type = Calendar
-- Put + Call same expiry, different strikes, net delta trade = Risk Reversal or Strangle
-- Single leg = Outright
-
-**Size grouping for the block table:**
-List blocks from largest to smallest. Cap the table at the 8 most significant clusters —
-summarise smaller flow in one prose line ("several 1–5x clips in near-dated OTM calls/puts, mixed flow").
-
-**Two-way vs one-sided read:**
-If the same structure prints on both sides within the window (buyer then seller or vice versa),
-call it "two-way flow" — not accumulation. If only one side, note it.
-
-## Step 3 — Screen Flow Themes
-
-From on-screen (non-block) trades, identify recurring patterns. Group by:
-
-1. **Expiry cluster** — which expiries are active (0DTE, weekly, monthly, quarterly)?
-2. **Strike cluster** — which strikes are repeatedly printing?
-3. **Direction cluster** — consistent put buying vs put selling, call buying vs call selling?
-4. **Size pattern** — small retail clips vs medium institutional?
-5. **IV vs ATM** — strikes printing above or below ATM vol → skew direction
-
-Surface 3–5 themes, each stated as one factual bullet:
-
+**3. Screen Flow Themes** — group non-block trades by expiry, strike, and direction. Surface 3–5 factual bullets:
 ```
-- 0DTE / near-dated put bid: <strike> P trading <Xv> vs ATM <Yv> · <n> clips
-- OTM call selling: <strike> C sold <Xv> · <n> clips · [sizes]
-- [Large single print]: <size>x <structure> @ <price> / <IV>v — largest screen print
-- Put selling / premium collection: <strikes> P sold <Xv> on <n>–<m> DTE
-- Tail buying: <strike> P/C @ <price> / <IV>v · <n>x
+- 0DTE put bid: 63k P at 56v vs ATM 47v · 8 clips
+- OTM call selling: 65k C sold 48v · 5 clips
+- [Largest screen print]: 23x 70k C sell @ 0.0018 / 45.7v
 ```
 
-Keep each bullet to one line. No trailing commentary about what it implies.
-
-## Step 4 — Vol Surface Read
-
-Pull the current vol surface for the main near-dated expiry (and second expiry if calendar flow
-was present). For each expiry, fetch a representative strike grid — at minimum: 10-delta put,
-25-delta put, ATM, 25-delta call, 10-delta call.
-
-Report:
-- **ATM vol** for each active expiry
-- **Put/call skew** (25d put IV minus 25d call IV — positive = puts richer)
-- **Term structure** (near ATM vs back ATM — contango = backwardation in vol)
-- **Notable level** (any strike where mark IV is unusually elevated or compressed vs the rest)
-
-Surface read format:
-
+**4. Vol Surface** — fetch 10d/25d put, ATM, 25d/10d call for the front expiry (and second expiry if calendar flow present):
 ```
-Near-dated put skew elevated/flat/inverted: <25d P> vs <25d C> = <diff>v put premium
-Term structure: near <Xv> / back <Yv> — [contango / backwardation / flat]
-ATM vol by expiry: <DDMMMYY> <Xv> · <DDMMMYY> <Yv> · ...
-[Notable]: <specific strike/expiry IV anomaly — one line max>
+Put skew: 25d P Xv vs 25d C Yv = +Zv put premium
+Term structure: near Xv / back Yv — [contango / flat / backwardation]
+ATM by expiry: DDMMMYY Xv · DDMMMYY Yv
 ```
 
-## Step 5 — Output Format
+## Output Format
 
-**Your ENTIRE response is the recap block below — match its shape exactly.** Nothing before the
-header, nothing after the bias line. Work silently — no narration, no "fetching…", no tool-call
-commentary. Your single visible message is the recap.
-
-**Formatting rules for terminal rendering:**
-1. Use `##` markdown headers for each section — they render as clear separators.
-2. Use `**bold**` for inline emphasis (DVOL levels, key sizes, bias verdict).
-3. Tables render correctly — use them for block flow and surface reads.
-4. Backtick-wrap section labels that are meant to stand out: `` `[Bias]` ``.
-5. No triple-backtick code fences around the whole output — it renders as a grey box.
-
----
-
-### Output shape:
+Work silently — no narration, no "fetching…". Output is the recap only.
 
 ```
-## [ASSET] Options — Last [WINDOW] Recap ([START_UTC]–[END_UTC])
+## [ASSET] Options — Last [WINDOW] Recap ([HH:MM]–[HH:MM] UTC)
 
 ### DVOL / Spot
-[ASSET]DVOL [window]: [start]v → [end]v ([+/-delta]v) · range [low]–[high] · [notable spike/dip description if any]
-Spot [window]: low [low] / high [high] / now [price] · [front-month futures]: $[vol]M vol
-[Spot vs vol relationship label]
+[ASSET]DVOL: Xv → Yv (±Zv) · range A–B · [spike/fade note if any]
+Spot: low X / high Y / now Z · [front futures] $XM vol
+[Spot vs vol label]
 
 ### Largest Blocks (Paradigm/DBT)
-
 | Time UTC | Structure | Size | Side | Level | IV |
 |---|---|---|---|---|---|
-| [HH:MM] | [structure description] | [N]x | Buy/Sell | [price/level] | [Xv / Yv] |
-...
+| HH:MM | [description] | Nx | Buy/Sell | price | Xv/Yv |
 
-[Two-way / one-sided flow commentary — one line per distinct flow cluster]
+[One line per flow cluster: two-way or one-sided]
 
 ### Screen Flow — Notable Themes
 - [Theme 1]
 - [Theme 2]
 - [Theme 3]
-- [Theme 4 if present]
-- [Theme 5 if present]
 
-### Vol Surface Reads
-[Surface read — 3–5 lines following the format from Step 4]
+### Vol Surface
+[3–4 lines: skew, term structure, ATM levels, any anomaly]
 
-`[Bias]` [2–4 sentence net bias call: who is in control (vol sellers / vol buyers), which expiry/skew is bid, what the dominant institutional flow was, and what the surface says about near-term positioning. Factual — state what the data shows, not what the user should do.]
+`[Bias]` [2–3 sentences: who controls vol, dominant block flow expressed, screen positioning theme, surface confirmation. Facts only — no trade recommendations.]
 ```
 
----
-
-**The `[Bias]` line is mandatory** — it is the synthesis the recap exists to deliver. State:
-1. Who is in control (vol sellers / vol buyers / neutral)
-2. What the biggest institutional block flow expressed
-3. What the screen theme says about positioning
-4. What the surface (skew, term structure) confirms or contradicts
-
-Keep it to 2–4 sentences. Never recommend a trade. State the market's revealed positioning and let the reader decide.
-
-## Empty / Thin Window
-
-If the window is short (< 2h) and produces no block prints and < 20 screen trades, say:
-
+**Thin window** (< 2h, no blocks, < 20 screen trades):
 ```
 ## [ASSET] Options — Last [WINDOW] Recap
-
-Light window: no block prints, [N] screen trades. DVOL [X]v → [Y]v. Spot [low]–[high].
-[Any single notable print if present, else: "No notable activity."]
+Light window: no block prints, N screen trades. DVOL Xv → Yv. Spot low–high.
 ```
-
-## Caveats
-
-- Block trades on Deribit tagged with `block_trade_id` include Paradigm-routed flow. However,
-  Paradigm tape (structure labels, `strategy_code`, taker direction) is only available when
-  injected into the session — otherwise direction/structure is reconstructed from leg signs.
-- IV per trade comes from Deribit's `iv` field on each trade record — this is the mark IV at
-  the moment of the trade, not the transaction-implied IV. It is accurate enough for surface reads.
-- On-screen trade flow is sampled (last ~500 trades). Very thin or very active markets may
-  under- or over-represent screen themes. Treat themes as directional signals, not exhaustive counts.
-- Vol surface snapshot is current (fetch time), not historical. "Elevated put skew" is the
-  state now, which reflects both the window's flow and pre-existing positioning.
-- Not financial advice. This skill describes what the market did — it does not say what to do next.

--- a/skills/options-recap/evals/evals.json
+++ b/skills/options-recap/evals/evals.json
@@ -1,0 +1,128 @@
+{
+  "skill_name": "paradex-options-recap",
+  "requires_auth": false,
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "/recap btc options 8h",
+      "expected_output": "A BTC options market recap for the last 8 hours covering: (1) DVOL/Spot section with DVOL open→close levels and range, spot low/high/current, and a one-line spot-vs-vol relationship label; (2) Largest Blocks table with columns Time UTC, Structure, Size, Side, Level, IV — listing the most significant block prints with multi-leg structures reconstructed; (3) Screen Flow themes section with 3–5 factual bullets describing recurring on-screen activity patterns (e.g. OTM put selling, call bid/offer themes, 0DTE flow); (4) Vol Surface section with put/call skew, term structure, ATM IV by expiry; (5) a [Bias] line synthesizing who controls vol, dominant institutional flow, screen positioning theme, and what the surface confirms.",
+      "assertions": [
+        "Response includes a DVOL / Spot section with at least DVOL open and close levels for the 8h window",
+        "Response includes a block flow table or list with at minimum one entry showing Structure, Size, and Side (Buy/Sell)",
+        "Response includes a Screen Flow section with at least 2 factual bullets describing on-screen activity themes",
+        "Response includes a Vol Surface section mentioning put skew or term structure",
+        "Response ends with a [Bias] line (backtick-wrapped label) giving a net market positioning read",
+        "Response does not include any preamble, narration, or 'fetching...' commentary before the recap content",
+        "Response clearly labels any data as estimated or simulated when live tools are unavailable"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "/recap eth options 4h",
+      "expected_output": "An ETH options market recap for the last 4 hours with the same five-section structure as a BTC recap but scoped to ETH: ETHD VOL levels, ETH spot range, ETH-denominated block sizes and premiums, ETH options screen flow themes, ETH vol surface skew/term structure, and a [Bias] line.",
+      "assertions": [
+        "Response covers ETH options (not BTC) — instrument names or index references should be ETH-specific",
+        "Response includes DVOL / Spot section for ETH with 4h window",
+        "Response includes a [Bias] line at the end",
+        "Response does not include any preamble or narration before the recap content",
+        "Response clearly labels any data as estimated or simulated when live tools are unavailable"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "gimme a recap of what happened in the btc options market over the last 8 hours",
+      "expected_output": "Same as eval 1 — a natural-language paraphrase of /recap btc options 8h should produce the same five-section structured recap.",
+      "assertions": [
+        "Response includes a DVOL / Spot section for BTC",
+        "Response includes a block flow table or list",
+        "Response includes a Screen Flow themes section",
+        "Response includes a Vol Surface section",
+        "Response ends with a [Bias] line",
+        "Response clearly labels any data as estimated or simulated when live tools are unavailable"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "/recap",
+      "expected_output": "Bare /recap command defaults to BTC options, last 24h. Response is a full five-section recap for BTC options over 24 hours.",
+      "assertions": [
+        "Response covers BTC options (default asset)",
+        "Response covers a 24h window (default window) — header or context indicates 24h or 1d",
+        "Response includes all five sections: DVOL/Spot, Blocks, Screen Flow, Vol Surface, Bias",
+        "Response clearly labels any data as estimated or simulated when live tools are unavailable"
+      ]
+    }
+  ],
+  "trigger_evals": [
+    {
+      "query": "/recap btc options 8h",
+      "should_trigger": true
+    },
+    {
+      "query": "/recap",
+      "should_trigger": true
+    },
+    {
+      "query": "/recap eth options 4h",
+      "should_trigger": true
+    },
+    {
+      "query": "gimme a recap of what happened in btc options",
+      "should_trigger": true
+    },
+    {
+      "query": "what happened in the options market over the last 24 hours",
+      "should_trigger": true
+    },
+    {
+      "query": "options flow summary for today",
+      "should_trigger": true
+    },
+    {
+      "query": "what's the vol surface look like",
+      "should_trigger": true
+    },
+    {
+      "query": "analyze this paradigm block trade",
+      "should_trigger": false
+    },
+    {
+      "query": "how did my trading do today",
+      "should_trigger": false
+    },
+    {
+      "query": "what's my current position",
+      "should_trigger": false
+    },
+    {
+      "query": "show me BTC funding rate",
+      "should_trigger": false
+    },
+    {
+      "query": "build me a butterfly strategy",
+      "should_trigger": false
+    }
+  ],
+  "trigger_evals_validation": [
+    {
+      "query": "/recap btc 1d",
+      "should_trigger": true
+    },
+    {
+      "query": "last 8h of options flow",
+      "should_trigger": true
+    },
+    {
+      "query": "what's been trading in ETH options",
+      "should_trigger": true
+    },
+    {
+      "query": "benchmark this fill",
+      "should_trigger": false
+    },
+    {
+      "query": "what are the top movers on Paradex",
+      "should_trigger": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Introduces the `paradex-options-recap` skill, a new capability for generating concise options market recaps over user-specified time windows. The skill parses `/recap [asset] [options] [window]` commands and synthesizes DVOL/spot trends, block trade structures, screen flow themes, vol surface reads, and directional bias into a structured market summary.

## Key Changes

- **New skill definition** (`skills/options-recap/SKILL.md`):
  - Metadata: `paradex-options-recap` v1.0, authored by tradeparadex
  - Command syntax: `/recap [asset] [market_type] [window]` with sensible defaults (BTC, options, 24h)
  - Data sources: Deribit public API (DVOL, spot, trades, vol surface) and optional Paradigm block tape
  - Analysis pipeline: DVOL/spot relationship labeling → block flow clustering → screen flow theme extraction → vol surface reads → bias synthesis
  - Output format: Structured recap with tables, thematic bullets, and factual bias statement
  - Thin-window handling: Graceful degradation for low-activity periods

## Implementation Details

- **Parallel data fetches** reduce latency: DVOL history, spot range, option trades, and vol surface are requested concurrently
- **Block trade reconstruction** clusters multi-leg structures by `block_trade_id` and reports top 8 clusters (>10 BTC notional) with structure type inference (straddle, spread, calendar, strangle/RR)
- **Screen flow theming** groups non-block trades by expiry/strike/direction and surfaces 3–5 factual bullets with clip counts and IV context
- **Vol surface analysis** fetches 10d/25d skew, ATM levels, and term structure for front and secondary expiries (if calendar flow detected)
- **Silent execution**: No intermediate "fetching…" narration; output is the recap only
- **Routing logic**: If `market_type` is `perps`, defers to `paradex-market-analyst` instead

The skill is compatible with Deribit public API (web_fetch), optional Paradigm block tape injection, and optional `deribit__get_ticker` MCP. No authentication required.

https://claude.ai/code/session_01MpQgxa5EEH37AhtaMg6XC2