### PR TITLE
options-recap: v2.0 — new fixed format with Snapshot/Block Flow/Bottom Line

### DIFF
--- a/skills/options-recap/SKILL.md
+++ b/skills/options-recap/SKILL.md
@@ -3,15 +3,15 @@ name: paradex-options-recap
 description: >
   Options market recap for a user-specified window, invoked via /recap. Parses
   "/recap [asset] [options] [window]" (e.g. "/recap btc options 8h") and produces
-  a fixed-format recap: DVOL/spot, volume by venue, block structure mix, flow themes,
-  vol surface movers, and a summary. Use when the user types /recap or asks for
+  a fixed-format recap: snapshot block, biggest print, block flow table, themes,
+  vol surface, and bottom line. Use when the user types /recap or asks for
   a market recap, options flow summary, "what happened in BTC options", or "last Xh of flow".
   The output format is fixed — always the same sections in the same order.
 compatibility: Deribit public API (web_fetch), Paradigm block tape (if injected),
   OKX/Bullish/IBIT public APIs (web_fetch). No authentication required.
 metadata:
   author: tradeparadex
-  version: "1.5"
+  version: "2.0"
 ---
 
 # Options Recap
@@ -71,39 +71,34 @@ Snapshot shape (omit any field to skip that section):
 }
 ```
 
-Returns `realized_vol`, `flow_greeks`, `top_blocks`, `vol_surface`. If a `derived` block is already injected into context, read it and skip the script. Verify with `python3 scripts/test_vol_math.py`.
+Returns `realized_vol`, `flow_greeks`, `top_blocks`, `vol_surface`. If a `derived` block is already injected into context, read it and skip the script.
 
 ## Analysis
 
-**1. DVOL / Spot** — open → close, range, spot range. Label the spot/vol relationship:
+**Snapshot** — pull spot, DVOL open→close, RV(7d) vs implied. VRP = implied − realized. Label:
 - spot↑ vol↓ → "vol sold through rally"
 - spot↓ vol↑ → "vol bid into weakness"
 - spot↑ vol↑ → "vol bought through rally"
 
-Add the realized-vs-implied line: `RV(7d) Xv vs implied Yv → [rich / cheap / in line]`. Realized must be a 7-day trailing window (not the recap window). Read from `derived.realized_vol` or the script — never estimate stdev/annualization.
+RV must be 7-day trailing window. Read from `derived.realized_vol` or the script — never estimate.
 
-**2. Volume** — sum notional across execution venues (Deribit, OKX, Bullish, IBIT) by asset (BTC/ETH/Other). P/C ratio = put notional / call notional. Paradigm is a routing layer; do not list it as a separate venue.
+**Block Flow** — read `top_blocks` from script. Biggest single print first, then structure table sorted by notional. Each row: structure name, total notional, detail line (strikes × size × side × IV). Mark `two-way` or one-sided from the field — do not infer.
 
-**3. Block Flow** — read `top_blocks` from the script: largest single print, then structure mix sorted by notional. Each entry has `structure`, `size_btc`, `notional_usd`, `side`, `expiry`. Mark side as `Two-way` or one-sided based on the field — do not infer intent.
-
-Then read net dealer positioning from `flow_greeks.positioning_label`. Possible labels:
-- short gamma → dealers chase moves
-- long gamma → dealers fade moves
+Dealer positioning from `flow_greeks.positioning_label`:
+- short gamma → chase spot, amplify moves
+- long gamma → fade moves
 - balanced → no decisive positioning
 
-State the label and the mechanical read. Do not extrapolate beyond it.
+**Themes** — screen (non-block) trades grouped by expiry/strike/direction. 2–4 bullets. Named, factual, no intent inference.
 
-**4. Screen Themes** — group non-block trades by expiry/strike/direction. Surface 3–5 factual bullets; one strike cluster per bullet.
-
-**5. Vol Surface** — discover-then-fetch, then read from `vol_surface`:
-1. Call `get_instruments` once. Pick front expiry (nearest ≥ now) plus second if block flow spans expiries.
-2. In each expiry, take ATM ± 4 strikes (calls + puts). ±4 brackets the 25Δ wings; ±2 extrapolates them.
-3. Fetch tickers in parallel. Pass `mark_iv` + `delta` + `spot` to the script.
-4. Read `atm_iv`, `rr_25d` (25Δ risk reversal = skew), `term_structure`, `skew_label`. Note `wings_extrapolated` if set.
+**Vol Surface** — discover-then-fetch:
+1. `get_instruments` once. Front expiry (nearest ≥ now) + second if blocks span expiries.
+2. ATM ± 4 strikes per expiry. Fetch tickers in parallel. Pass `mark_iv` + `delta` + `spot` to script.
+3. Read `atm_iv`, `rr_25d`, `butterfly_25d`, `term_structure`. Note `wings_extrapolated` if set.
 
 ## Output Format — FIXED
 
-All six sections in this exact order, every recap. Section 3 is always blocks; section 4 is always themes. Never reorder, add, or drop sections.
+Six sections, this exact order, every recap. Never reorder, add, or drop sections.
 
 Work silently — no narration. If live tools are unavailable, prepend one line: `⚠ Data estimated — no live feed available.`
 
@@ -111,67 +106,56 @@ Work silently — no narration. If live tools are unavailable, prepend one line:
 
 **Shape to mirror:**
 
-**BTC Options · [WINDOW] Recap · [HH:MM]–[HH:MM] UTC**
+**[ASSET] Options · [WINDOW] Recap · [HH:MM]–[HH:MM] UTC**
 
----
+**Snapshot**
 
-**DVOL / Spot**
+```yaml
+Spot      $[X]        [up/down X%] (from $[Y])
+DVOL      [X]v        [flat/rising/falling] ([open] -> [close])
+RV 7d     [X]v        implied [CHEAP/RICH/IN LINE] vs realized
+VRP       [±X]v       vol [underpriced/overpriced] vs delivered
+Volume    $[X]M       [primary venue] (incl. Paradigm)
+P/C       [X.Xx]x     [calls/puts] dominant
+```
 
-[ASSET] DVOL: Xv → Yv (±Zv) · range A–B · [rising / drifting lower / flat]
-Spot: now $X (from $Y) · [spot/vol read]
-RV(7d) Rv vs implied Yv → [rich / cheap / in line]
+**Biggest Print**
 
-**Volume · $[TOTAL]M · P/C ratio [X.Xx] ([puts/calls] dominant)**
+```yaml
+[DDMMMYY] [structure]   [Nx]   $[X]M   [HH:MM] UTC   via [Venue]
+```
 
-| Venue | BTC | ETH | Other | Total |
-|---|---|---|---|---|
-| Deribit | $XM | $XM | $XM | $XM |
-| OKX | $XM | $XM | $XM | $XM |
-| Bullish | $XM | $XM | $XM | $XM |
-| IBIT | $XM | $XM | $XM | $XM |
-| **Total** | **$XM** | **$XM** | **$XM** | **$XM** |
+**Block Flow — $[X]M / [N] blocks**
 
----
+```yaml
+#  Structure            Notl     Detail
+-  -------------------  -------  ------------------------------------------
+1  [structure]          $[X]M    [strikes] x[size] - [SIDE] [IV]v [two-way/one-sided]
+2  …
+```
 
-**Largest Blocks · Deribit / OKX / Bullish / IBIT (incl. Paradigm-routed)**
+Dealer positioning: [short/long] vega + [short/long] gamma → [mechanical read]; [implication].
 
-**Largest single:** [DDMMMYY] [Strike] [Structure] · [Nx] · $[X]M · [Venue] · [HH:MM] UTC
+**Themes**
+1. [Theme name] — [structure, strikes, size, IV, side]. [One factual line.]
+2. …
 
-| Structure | Notl | Where active |
-|---|---|---|
-| Outright puts | $XM | Jun 55k P ×200, Sep 50k P ×150 |
-| Put spreads | $XM | Jun 60/55k ×250 |
-| … | … | … |
-
-Dealer positioning: [long/short] gamma/vega · ≈$X vega/vol-pt
-
----
-
-**Flow Themes**
-
-[Theme name] — [structure, size, strikes, IV, side]. [One factual line if needed.]
-
-[3–5 themes. Facts only — no intent inference.]
-
----
+[2–4 themes. Facts only — no intent inference.]
 
 **Vol Surface**
+Skew: front 25Δ RR [±X]v → [puts bid / calls bid] · Term: [front]v → [back]v → [contango / flat / backwardation]
 
-Skew: 25Δ RR Zv — [puts bid / calls bid]
-Term structure: front Xv / back Yv — [contango / flat / backwardation]
-ATM by expiry: DDMMMYY Xv · DDMMMYY Yv
+```yaml
+Expiry     ATM                  25d RR               Fly
+---------  -------------------  -------------------  -------------------
+[DDMMMYY]  [X.X] → [Y.Y]v      [±X.X] → [±Y.Y]v    [X.X] → [Y.Y]v
+…
+```
 
-| Strike | IV | Δ IV | OI | Δ OI |
-|---|---|---|---|---|
-| DDMMMYY Xk C/P | Xv | ±Xv | X BTC | ±X BTC |
+`* wings extrapolated` (if applicable)
 
-[5–8 rows sorted by |Δ IV| descending]
-
----
-
-**Summary**
-
-[1–2 sentences. State the facts of the session — who was in the market, what they did. No forecasts, no recommendations.]
+**Bottom Line**
+[1–2 sentences. Calls/puts lead, volume, dominant block structure. Dealer positioning vs vol surface vs RV/IV gap. No forecasts.]
 
 ---
 

--- a/skills/options-recap/evals/evals.json
+++ b/skills/options-recap/evals/evals.json
@@ -5,26 +5,27 @@
     {
       "id": 1,
       "prompt": "/recap btc options 8h",
-      "expected_output": "A BTC options market recap for the last 8 hours in the fixed 6-section format: (1) DVOL/Spot — DVOL open→close, range, drift label, spot range and vol/spot read; (2) Volume table — per-venue (Deribit/OKX/Bullish/IBIT) broken into BTC/ETH/Other with P/C ratio; (3) Largest Blocks — single largest print callout, then structure mix table with Notional and Where Active columns; (4) Flow Themes — 3–5 named themes with strikes/sizes/IV; (5) Vol Surface Movers — table with IV, Δ IV, OI, Δ OI; (6) Summary — 1–2 sentences. Data labeled as estimated when live tools unavailable.",
+      "expected_output": "A BTC options recap for the last 8 hours in the fixed 6-section format: (1) Snapshot yaml block — Spot, DVOL open→close, RV 7d, VRP, Volume, P/C; (2) Biggest Print — single largest block one-liner; (3) Block Flow table — numbered rows with Structure, Notl, Detail columns + dealer positioning line; (4) Themes — 2–4 named factual bullets; (5) Vol Surface — skew/term line + expiry table (ATM, 25d RR, Fly); (6) Bottom Line — 1–2 sentences. Data labeled as estimated when live tools unavailable.",
       "assertions": [
-        "Response includes a DVOL / Spot section with DVOL open and close levels and a spot range for the 8h window",
-        "Response includes a volume table with per-venue breakdown (Deribit, OKX, Bullish, or IBIT) and a P/C ratio",
-        "Response includes a block structure mix table with a Notional column and a 'Where active' or equivalent description column",
-        "Response includes a Flow Themes section with at least 2 named themes describing specific strikes, sizes, or structures",
-        "Response includes a Vol Surface section with IV levels and at least one Δ IV value",
-        "Response includes a Summary section (1–2 sentences) as the final section",
+        "Response includes a Snapshot section as a code block with Spot, DVOL, RV 7d, VRP, Volume, and P/C fields",
+        "Response includes a Biggest Print section with a single largest block identified",
+        "Response includes a Block Flow section with a numbered table (Structure, Notl, Detail columns) and a dealer positioning line",
+        "Response includes a Themes section with at least 2 named bullets describing specific strikes, sizes, or structures",
+        "Response includes a Vol Surface section with a skew/term summary line and a table showing ATM, 25d RR, and Fly per expiry",
+        "Response includes a Bottom Line section (1–2 sentences) as the final section",
         "Response clearly labels any data as estimated or simulated when live tools are unavailable — does not present fabricated numbers as confirmed live data"
       ]
     },
     {
       "id": 2,
       "prompt": "/recap eth options 4h",
-      "expected_output": "An ETH options recap for the last 4 hours in the fixed 6-section format, scoped to ETH: ETH DVOL levels, ETH spot range, ETH-denominated volumes and blocks, ETH options flow themes, ETH vol surface, and a Summary line. Data labeled as estimated.",
+      "expected_output": "An ETH options recap for the last 4 hours in the fixed 6-section format, scoped to ETH: ETH DVOL levels, ETH spot range, ETH volumes, ETH blocks, ETH flow themes, ETH vol surface, and a Bottom Line. Data labeled as estimated.",
       "assertions": [
         "Response covers ETH options — instrument names, DVOL reference, or spot prices are ETH-specific",
-        "Response includes a DVOL / Spot section for ETH with a 4h window",
-        "Response includes a volume section or table",
-        "Response includes a Flow Themes or block flow section",
+        "Response includes a Snapshot section for ETH with DVOL and spot data",
+        "Response includes a Block Flow section or states No data",
+        "Response includes a Themes section or states No data",
+        "Response includes a Vol Surface section",
         "Response clearly labels any data as estimated or simulated when live tools are unavailable"
       ]
     },
@@ -33,11 +34,11 @@
       "prompt": "gimme a recap of what happened in the btc options market over the last 8 hours",
       "expected_output": "Same as eval 1 — a natural-language paraphrase of /recap btc options 8h produces the same fixed 6-section recap.",
       "assertions": [
-        "Response includes a DVOL / Spot section for BTC",
-        "Response includes a block flow or structure mix section",
-        "Response includes a Flow Themes section with named themes",
-        "Response includes a Vol Surface section",
-        "Response includes a Summary or Bias section as the final section",
+        "Response includes a Snapshot section for BTC with Spot, DVOL, and P/C fields",
+        "Response includes a Block Flow section with a structure table",
+        "Response includes a Themes section with named bullets",
+        "Response includes a Vol Surface section with expiry-level ATM IVs",
+        "Response includes a Bottom Line section as the final section",
         "Response clearly labels any data as estimated or simulated when live tools are unavailable"
       ]
     },
@@ -48,8 +49,9 @@
       "assertions": [
         "Response covers BTC options (default asset) — header or content references BTC",
         "Response covers a 24h window — header or context indicates 24h or 1d",
-        "Response includes a DVOL / Spot section",
-        "Response includes a block flow or structure mix section",
+        "Response includes a Snapshot section",
+        "Response includes a Block Flow section",
+        "Response includes a Bottom Line section",
         "Response clearly labels any data as estimated or simulated when live tools are unavailable"
       ]
     },
@@ -57,18 +59,18 @@
       "id": 5,
       "prompt": "/recap btc options 8h",
       "context": "fixture:btc_8h_2026-06-05.json",
-      "expected_output": "A BTC options recap for an 8h window where DVOL rose from 46.34v to 48.16v (+1.8v), spot fell from ~63,896 to ~61,060 (vol bid into weakness), 7-day realized vol (~53.9v) ran above implied so the vol risk premium reads cheap, the largest block was a 200x Strangle/RR on 26JUN26, screen flow was dominated by 12JUN26 put buying, net flow left dealers short gamma (positioned to chase and amplify spot moves), and the vol surface shows a downside skew (front 25Δ RR ~-12v, puts bid) with a backwardated term structure (front ATM ~83v over back ATM ~68v).",
+      "expected_output": "A BTC options recap for an 8h window where DVOL rose from 46.34v to 48.16v (+1.8v), spot fell from ~63,896 to ~61,060 (vol bid into weakness), 7-day realized vol (~53.9v) ran above implied so VRP is negative (implied cheap), the largest block was a 200x Strangle/RR on 26JUN26, screen flow was dominated by 12JUN26 put buying, net flow left dealers short gamma (positioned to chase and amplify spot moves), and the vol surface shows a downside skew (front 25Δ RR ~-12v, puts bid) with a backwardated term structure (front ATM ~83v over back ATM ~68v).",
       "assertions": [
         "DVOL open is reported as approximately 46.3v–46.4v",
         "DVOL close is reported as approximately 48.1v–48.2v",
         "DVOL shows an increase (not a decrease) over the 8h window",
         "Spot-vol relationship is described as vol rising into spot weakness, or equivalent (e.g. 'vol bid into weakness', 'vol bought on dip')",
         "Recap reports 7-day realized vol near 53.9v (within ±3v)",
-        "Recap reads the vol risk premium as implied cheap vs realized (realized running above implied / DVOL below realized), or equivalent",
+        "VRP is reported as negative — implied cheap vs realized (realized running above implied)",
         "Largest block is identified as a Strangle or Risk Reversal structure on 26JUN26 — size reported as either ~100 BTC per leg or ~200 BTC total (two-leg cluster)",
         "Largest block is described as two-way flow (both buy and sell legs present — one leg is a put buy, the other is a call sell)",
         "Recap reads net dealer positioning as short gamma — i.e. dealers chase/amplify spot moves — consistent with customers net buying vol/gamma",
-        "Screen flow section mentions put buying in June expiries as the dominant theme",
+        "Themes section mentions put buying in June expiries as the dominant screen theme",
         "Vol surface section reports front-expiry (5JUN26) ATM IV near 83v (within ±4v)",
         "Vol surface skew is described as downside / puts bid (front 25-delta risk reversal negative, around -12v)",
         "Term structure is described as backwardation / inverted (front expiry IV above back expiry IV)"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Replaces the old 6-section DVOL/Volume/Blocks/Themes/Surface/Summary layout with a tighter trader-first format
- Monospace code blocks now use `yaml` syntax highlighting (blue/teal tint) for the Snapshot, Biggest Print, Block Flow, and Vol Surface tables
- Adds **VRP** (vol risk premium = implied − realized) as an explicit field in the Snapshot block
- Biggest Print is now its own callout section — one line, scannable at a glance
- Block Flow table is numbered with Structure / Notl / Detail columns; dealer positioning line follows immediately
- Vol Surface expiry table now shows ATM / 25d RR / Fly per row (replaces the old IV movers table)
- Bottom Line replaces Summary — same 1–2 sentence constraint, tighter label
- Evals updated to assert the new section names and structure

## Test plan
- [ ] Eval 1–4 (sim mode): Snapshot block present with all 6 fields; Biggest Print, Block Flow, Themes, Vol Surface, Bottom Line all present; estimated-data label when live tools unavailable
- [ ] Eval 5 (fixture `btc_8h_2026-06-05.json`): DVOL 46.3→48.2, spot weakness read, RV ~53.9v, VRP negative, largest block = 26JUN26 strangle/RR two-way, dealer short gamma, front ATM ~83v, puts bid skew, backwardated term structure

https://claude.ai/code/session_01MpQgxa5EEH37AhtaMg6XC2
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpQgxa5EEH37AhtaMg6XC2)_