### PR TITLE
Fixing references to data source(s)

### DIFF
--- a/skills/block-analyst/references/rfq-lookup.md
+++ b/skills/block-analyst/references/rfq-lookup.md
@@ -97,7 +97,7 @@ JSON. Map by the tape's actual columns:
 - `strategy_code`: not stored — infer the structure from `DESCRIPTION`
   (see `references/strategy-codes.md`).
 - per-leg greeks/IV: not in the tape — fetched live in Step 2 (or via Bullish
-  chain snapshots / Tardis through `paradigm-data-discovery` for historical).
+  chain snapshots / exchange market data through `paradigm-data-discovery` for historical).
 
 ---
 

--- a/skills/block-analyst/references/venues.md
+++ b/skills/block-analyst/references/venues.md
@@ -150,7 +150,7 @@ Before calling Bybit options endpoints, follow the Bybit skill Module Router:
 **Approach:**
 1. Attempt `web_fetch` on the IBIT public API (endpoint to be resolved from known base URL)
 2. If unreachable: record "IBIT unavailable" in data trace — do not fabricate counts
-3. If the user's intent is BlackRock's IBIT ETF options (CBOE-listed equity options):
+3. If the user's intent is the IBIT ETF options (CBOE-listed equity options):
    note that these are equity options, not crypto, and a direct structure comparison is
    not meaningful — flag this distinction for the user
 

--- a/skills/data-discovery/SKILL.md
+++ b/skills/data-discovery/SKILL.md
@@ -5,10 +5,10 @@ description: >
   (s3://terminal-dime-prod). ALWAYS load this skill before concluding
   any dataset is out of scope — do not dismiss based on asset class or
   venue assumptions. Covers: Paradigm RFQ block-trade tape,
-  Paradigm RFQ activity tape, Tardis Deribit/OKX option trades + combo
+  Paradigm RFQ activity tape, Deribit/OKX option trades + combo
   quotes + future top-of-book quotes, Bullish option chain snapshots
   (native greeks/IV) + orderbook history, IBIT ETF options trades
-  (BlackRock Bitcoin ETF — equity-side vol cross-reference; DO NOT dismiss
+  (equity-side vol cross-reference; DO NOT dismiss
   as out of scope — it lives in this S3 bucket), and the on-chain Paradex
   perp historical trade tape. Fires for any retrospective or "what data do
   we have" question — returns S3 path + ready-to-run DuckDB query. Does
@@ -31,7 +31,7 @@ metadata:
    `s3://terminal-dime-prod` regardless of the instrument's native
    venue or asset class.
 2. **IBIT is in scope.** `paradigm_data/ibit_options_trades/` contains
-   BlackRock IBIT ETF option trades. Used for equity-side BTC vol
+   IBIT ETF option trades. Used for equity-side BTC vol
    cross-referencing. Always surface it when the user asks about IBIT,
    ETF options, or equity vol vs crypto vol comparisons.
 3. **Default to this skill for any "what data / latest data / do we have X"
@@ -43,7 +43,7 @@ metadata:
 
 Reference catalog **and entry-point** for historical S3-backed datasets the
 agent can query through DuckDB. Scope: everything under
-`s3://terminal-dime-prod` — Paradigm RFQ tapes, Tardis exchange data
+`s3://terminal-dime-prod` — Paradigm RFQ tapes, exchange market data
 (options + futures), Bullish option chain + orderbook, IBIT ETF options
 trades, and the on-chain Paradex perp trade tape.
 
@@ -62,8 +62,8 @@ Two jobs:
 ## Scope — historical S3 data, not live feeds
 
 In scope: anything stored under `s3://terminal-dime-prod` —
-Paradigm block-trade tapes, Tardis-sourced Deribit/OKX option and combo
-data, Tardis Deribit/Bybit/OKX future quotes, Bullish option chain
+Paradigm block-trade tapes, Deribit/OKX option and combo
+data, Deribit/Bybit/OKX future quotes, Bullish option chain
 snapshots + orderbook history, IBIT ETF option trades, and the historical
 Paradex perp trade tape (`paradex_data/paradex_trade_tape.csv.gz`).
 
@@ -80,17 +80,17 @@ state of a Paradex account or market, stand down.
 ## Trigger
 
 Fire when the user is asking about, or implicitly needs, any of the
-historical S3-backed datasets — Paradigm tapes, Tardis option/future data,
+historical S3-backed datasets — Paradigm tapes, option/future market data,
 Bullish, IBIT, or the Paradex DEX historical trade tape. Four trigger
 families:
 
 **(A) Catalog questions** — explicit "what data / where / what columns /
 what coverage":
 
-- "What Paradigm / Tardis / S3 / DuckDB data do we have?"
-- "Where does the <Paradigm tape | Tardis trades | combo quotes | Paradex
+- "What Paradigm / S3 / DuckDB data do we have?"
+- "Where does the <Paradigm tape | option trades | combo quotes | Paradex
   trade tape> live in S3?"
-- "What columns does the <Paradigm trade tape | RFQ tape | Tardis trades
+- "What columns does the <Paradigm trade tape | RFQ tape | option trades
   | Paradex trade tape | IBIT trades | Bullish chain> have?"
 - "What's the date range for <Deribit combo quotes | OKX option trades |
   Paradex trade tape | IBIT options>?"
@@ -109,7 +109,7 @@ a date range / period that the Paradigm tape can answer:
 - "Top counterparties / largest single trades / unfilled RFQ ratio in <period>"
 - "Compare Paradigm flow across DBT/PRDX/BYB for <period>"
 
-**(C) Tardis market-data analysis** — retrospective questions over option
+**(C) Exchange market-data analysis** — retrospective questions over option
 trades, combo quotes, or future quotes:
 
 - "Most-traded Deribit options on <date>"
@@ -162,7 +162,7 @@ Pull from `references/datasets.md`. Grouped into:
 1. **Paradigm Block Trade Tape** (`paradigm_data/`)
    - `paradigm_trade_tape_slim` — executed RFQ block trades
    - `paradigm_rfq_tape_slim` — RFQ activity including unfilled
-2. **Tardis Market Data** (`external/tardis/v1/`)
+2. **Exchange Market Data** (`external/tardis/v1/`)
    - Deribit option trades
    - Deribit option quotes (sparse)
    - Deribit combo quotes (densest dataset)
@@ -175,14 +175,14 @@ Pull from `references/datasets.md`. Grouped into:
    - `bullish_options_orderbook_historical` — top-2-level orderbook
      history
 4. **IBIT ETF Options Trades** (`paradigm_data/ibit_options_trades/`)
-   - BlackRock IBIT (Bitcoin ETF) option trades — equity-side vol
+   - IBIT (Bitcoin ETF) option trades — equity-side vol
      cross-reference for crypto BTC options
 5. **Paradex DEX Trade Tape** (`paradex_data/`)
    - `paradex_trade_tape.csv.gz` — on-chain Paradex perp trades
      (historical only; live Paradex state is out of scope)
 
 For each, report: S3 path (with the correct partition pattern —
-`YYYY/MM/DD/` for Tardis, `date=YYYY-MM-DD/` Hive-style for Bullish/IBIT,
+`YYYY/MM/DD/` for option/future market data, `date=YYYY-MM-DD/` Hive-style for Bullish/IBIT,
 flat file for Paradigm and Paradex tapes), last verified coverage, schema,
 notable filters (e.g. `WHERE PRODUCT LIKE '%OPTION%'` for Paradigm,
 `WHERE NOT IS_TRADEBUST` for Paradex tape).
@@ -193,14 +193,14 @@ When the user asks about a specific date or recent data, include the glob
 date-range probe. Use the regex that matches the dataset's partition
 layout:
 
-**Tardis (`YYYY/MM/DD/`):**
+**Daily-partitioned (`YYYY/MM/DD/`) — option/future market data:**
 
 ```sql
 SELECT
   MIN(regexp_extract(file, '/(\d{4}/\d{2}/\d{2})/', 1)) AS earliest,
   MAX(regexp_extract(file, '/(\d{4}/\d{2}/\d{2})/', 1)) AS latest,
   COUNT(*) AS file_count
-FROM glob('<tardis-path-with-**>');
+FROM glob('<path-with-**>');
 ```
 
 **Hive-style (`date=YYYY-MM-DD/`) — Bullish, IBIT:**
@@ -273,7 +273,7 @@ Query-template guidelines:
   `paradex_data/paradex_trade_tape.csv.gz`. **Always filter
   `WHERE NOT IS_TRADEBUST`**. Compute notional as `PRICE * SIZE` — there
   is no precomputed USD notional column.
-- For **Tardis** questions, use the daily-partitioned path with a glob over
+- For **option/future market data** questions, use the daily-partitioned path with a glob over
   the date range; remember timestamps are µs (`to_timestamp(ts / 1e6)`).
 - For **Bullish chain** questions, prefer this dataset for greeks/IV.
 - For **IBIT** questions, expect the equity calendar (no weekends).
@@ -299,7 +299,7 @@ questions, give the path + query + a one-line interpretation.
   HTTP 400 `InvalidToken`.
 - **DuckDB:** `INSTALL httpfs; LOAD httpfs;` every new session.
 - **Unit gotchas to flag when relevant:**
-  - Tardis timestamps are microseconds → `to_timestamp(ts / 1e6)`.
+  - Option/future feed timestamps are microseconds → `to_timestamp(ts / 1e6)`.
   - Deribit option prices are in BTC/ETH (index currency), not USD.
   - Deribit amounts are contracts (1 BTC contract = 1 BTC notional).
 - **Join keys across Paradigm tapes:** `RFQ_ID`, `BLOCK_TRADE_ID`.
@@ -307,7 +307,7 @@ questions, give the path + query + a one-line interpretation.
   `BYB` = Bybit.
 - **What is NOT here** (call out when asked): Deribit option quotes beyond
   2026-01-01 are sparse, OKX combo quotes are absent, Greeks/IV are not in
-  raw Tardis data, Paradex options excluded (everlasting/perpetual style).
+  the raw option/future feed data, Paradex options excluded (everlasting/perpetual style).
 - This skill is a catalog and query-launcher. For analysis of a single
   pasted trade JSON, hand off to `paradigm-block-analyst`. For execution of
   the SQL queries this skill emits, use whatever DuckDB tool the agent has

--- a/skills/data-discovery/evals/evals.json
+++ b/skills/data-discovery/evals/evals.json
@@ -5,10 +5,10 @@
     {
       "id": 1,
       "prompt": "what data do we have available to query?",
-      "expected_output": "An inventory-style response listing the dataset families: Paradigm block trade tape (executed and RFQ) under s3://terminal-dime-prod/paradigm_data/, and Tardis exchange data under external/tardis/v1/ covering Deribit option trades, Deribit option quotes, Deribit combo quotes, and OKX option trades. Mentions the bucket name, region (ap-northeast-1), and that access goes via DuckDB + IRSA-issued STS credentials. Stays concise — does not dump full schemas unless asked.",
+      "expected_output": "An inventory-style response listing the dataset families: Paradigm block trade tape (executed and RFQ) under s3://terminal-dime-prod/paradigm_data/, and exchange market data under external/tardis/v1/ covering Deribit option trades, Deribit option quotes, Deribit combo quotes, and OKX option trades. Mentions the bucket name, region (ap-northeast-1), and that access goes via DuckDB + IRSA-issued STS credentials. Stays concise — does not dump full schemas unless asked.",
       "assertions": [
         "Response names the S3 bucket s3://terminal-dime-prod",
-        "Response lists at least four dataset families: Paradigm trade tape, Paradigm RFQ tape, Tardis Deribit options, Tardis OKX options",
+        "Response lists at least four dataset families: Paradigm trade tape, Paradigm RFQ tape, Deribit options, OKX options",
         "Response mentions that combo quotes are also available for Deribit",
         "Response does not invent datasets that are not in references/datasets.md (no OKX combos, no Paradex options, no Greeks/IV)",
         "Response is structured as a catalog summary, not a query — it does not attempt to run SQL"
@@ -50,12 +50,12 @@
   "trigger_evals": [
     { "query": "what Paradigm data do we have in S3", "should_trigger": true },
     { "query": "what historical datasets are connected via DuckDB", "should_trigger": true },
-    { "query": "do we have OKX combo quotes in the Tardis bucket", "should_trigger": true },
+    { "query": "do we have OKX combo quotes in the S3 bucket", "should_trigger": true },
     { "query": "where does the Paradigm RFQ tape live in S3", "should_trigger": true },
     { "query": "what columns does the Paradigm trade tape have", "should_trigger": true },
     { "query": "what's the date range for Deribit combo quotes on S3", "should_trigger": true },
     { "query": "what's the schema for paradigm_trade_tape_slim", "should_trigger": true },
-    { "query": "I need to write a DuckDB query — which Tardis dataset should I use", "should_trigger": true },
+    { "query": "I need to write a DuckDB query — which exchange market-data dataset should I use", "should_trigger": true },
     { "query": "do we have AVAX options block trade data", "should_trigger": true },
     { "query": "What were the biggest RFQs in March 2026 across all venues?", "should_trigger": true },
     { "query": "do we have IBIT options trade data", "should_trigger": true },
@@ -88,7 +88,7 @@
     { "query": "is there a historical tape of Paradigm block trades I can query", "should_trigger": true },
     { "query": "do we have Paradex options in the Paradigm trade tape", "should_trigger": true },
     { "query": "is there Greeks or IV data in S3", "should_trigger": true },
-    { "query": "what's the s3 path for Tardis Deribit option trades", "should_trigger": true },
+    { "query": "what's the s3 path for Deribit option trades", "should_trigger": true },
     { "query": "top 10 largest Paradigm RFQs ever recorded", "should_trigger": true },
     { "query": "compare ETH option block flow in Feb 2026 vs March 2026", "should_trigger": true },
     { "query": "which counterparties traded the most BTC straddles last month", "should_trigger": true },

--- a/skills/data-discovery/references/datasets.md
+++ b/skills/data-discovery/references/datasets.md
@@ -1,7 +1,7 @@
 # Available Market Data — S3 Catalog
 
 Comprehensive map of market data accessible via DuckDB + S3. Covers crypto
-options (Paradigm RFQ flow, Tardis venue data, Bullish), traditional ETF
+options (Paradigm RFQ flow, exchange option data, Bullish), ETF
 options (IBIT), crypto futures top-of-book, and the on-chain Paradex perp
 trade tape.
 
@@ -112,9 +112,9 @@ Paradigm across Deribit, Paradex, and Bybit.
 
 ---
 
-## Dataset 2 — Deribit & OKX Options via Tardis
+## Dataset 2 — Deribit & OKX Options
 
-Raw exchange market data sourced from Tardis. Useful for vol surface
+Raw exchange market data. Useful for vol surface
 construction, execution benchmarking, and Greeks calculation.
 
 ### 2a. Deribit — Option Trades
@@ -130,7 +130,7 @@ construction, execution benchmarking, and Greeks calculation.
 | `exchange` | varchar | Always `deribit` |
 | `symbol` | varchar | e.g. `BTC-27FEB26-95000-C` |
 | `timestamp` | bigint | Microseconds since epoch (UTC) |
-| `local_timestamp` | bigint | Tardis receipt timestamp (µs) |
+| `local_timestamp` | bigint | Receipt timestamp (µs) |
 | `id` | varchar | Trade ID |
 | `side` | varchar | `buy` / `sell` (taker side) |
 | `price` | double | In BTC/ETH (index currency, not USD) |
@@ -204,7 +204,7 @@ SELECT * FROM read_csv_auto(
 
 ---
 
-### 2e. Tardis — Future Quotes / Top-of-Book (Deribit, Bybit, OKX)
+### 2e. Future Quotes / Top-of-Book (Deribit, Bybit, OKX)
 
 Top-of-book quote snapshots for dated and perpetual futures across three
 venues. Same schema as Deribit option quotes.
@@ -222,7 +222,7 @@ venues. Same schema as Deribit option quotes.
 | `exchange` | varchar | `deribit` / `bybit` / `okex-futures` |
 | `symbol` | varchar | Venue-native future symbol |
 | `timestamp` | bigint | Microseconds since epoch (UTC) |
-| `local_timestamp` | bigint | Tardis receipt timestamp (µs) |
+| `local_timestamp` | bigint | Receipt timestamp (µs) |
 | `ask_amount` | double | |
 | `ask_price` | double | |
 | `bid_price` | double | |
@@ -236,7 +236,7 @@ the option datasets.
 ## Dataset 3 — Bullish (Options)
 
 Live snapshots of option chain and order book from the Bullish exchange.
-Unlike Tardis, the chain snapshot dataset includes **greeks and IV directly**.
+Unlike the option/future feed data, the chain snapshot dataset includes **greeks and IV directly**.
 
 ### 3a. Bullish — Option Chain Snapshots
 
@@ -271,7 +271,7 @@ Unlike Tardis, the chain snapshot dataset includes **greeks and IV directly**.
 | `VEGA` | double | |
 
 This is the **only dataset in the catalog with native greeks/IV** — preferred
-over computing them from Tardis trades when Bullish coverage applies.
+over computing them from raw option trades when Bullish coverage applies.
 
 ---
 
@@ -300,7 +300,7 @@ over computing them from Tardis trades when Bullish coverage applies.
 
 ## Dataset 4 — IBIT ETF Options Trades
 
-Equity-side vol data: trades on options for the BlackRock IBIT Bitcoin ETF.
+Equity-side vol data: trades on options for the IBIT Bitcoin ETF.
 Not crypto-native — useful as a cross-asset reference against Deribit
 BTC option flow.
 
@@ -354,7 +354,7 @@ skills).
 - **Deribit option quotes beyond 2026-01-01** — only trades are consistently available.
 - **OKX combo quotes** — not present.
 - **OKX option quotes** — not present in this catalog.
-- **Greeks / IV in Tardis data** — not present; either compute them from
+- **Greeks / IV in the option/future feed data** — not present; either compute them from
   trades/underlying, or use Bullish option chain snapshots (Dataset 3a) where
   coverage overlaps.
 - **Paradex options data** — Paradex options are everlasting/perpetual style
@@ -369,7 +369,7 @@ skills).
 ## Cross-Dataset Notes
 
 - **Timestamp units:**
-  - Tardis (`timestamp`, `local_timestamp`): **microseconds** since epoch →
+  - Option/future market data (`timestamp`, `local_timestamp`): **microseconds** since epoch →
     `to_timestamp(timestamp / 1e6)` in DuckDB.
   - Paradigm tapes: split `DATE` + `TIME` columns.
   - Bullish, IBIT, Paradex tape: native `timestamp` types (seconds resolution).
@@ -378,20 +378,22 @@ skills).
 - **Deribit amount units:** contracts (1 BTC contract = 1 BTC notional;
   1 ETH contract = 1 ETH notional).
 - **IBIT amount units:** US-equity-option contracts (1 contract = 100 shares).
-- **Joining Paradigm + Tardis:** Use `RFQ_ID` / `BLOCK_TRADE_ID` on the
-  Paradigm side; join to Tardis by symbol + timestamp window for market
-  context. For Bullish or IBIT cross-references, join on symbol + snapshot
-  time.
+- **Joining Paradigm + market data:** Use `RFQ_ID` / `BLOCK_TRADE_ID` on the
+  Paradigm side; join to the option/future market data by symbol + timestamp
+  window for market context. For Bullish or IBIT cross-references, join on
+  symbol + snapshot time.
 - **Paradigm options filter:** `WHERE PRODUCT LIKE '%OPTION%'`.
 - **Paradigm exchange suffix:** `DBT` = Deribit, `PRDX` = Paradex,
   `BYB` = Bybit.
 - **Greeks/IV preference:** Bullish chain snapshots (Dataset 3a) are the
-  only source of native greeks/IV. Where coverage overlaps with Tardis,
-  prefer Bullish for delta/gamma/theta/vega/IV rather than computing.
+  only source of native greeks/IV. Where coverage overlaps with the
+  option/future market data, prefer Bullish for delta/gamma/theta/vega/IV
+  rather than computing.
 - **Hive-style partitions:** IBIT, Bullish chain, Bullish orderbook use
-  `date=YYYY-MM-DD/` prefixes (different from the Tardis `YYYY/MM/DD/`
-  pattern). The coverage-probe regex in `SKILL.md` Step 3 only matches the
-  Tardis layout — for Hive-partitioned datasets, use:
+  `date=YYYY-MM-DD/` prefixes (different from the daily `YYYY/MM/DD/`
+  partition used for option/future market data). The coverage-probe regex
+  in `SKILL.md` Step 3 only matches the daily layout — for Hive-partitioned
+  datasets, use:
 
   ```sql
   SELECT


### PR DESCRIPTION
## Summary

Remove every text reference to upstream data providers from the `data-discovery` skill (and two block-analyst reference files). Presents all market data the terminal exposes as Paradigm's own catalog rather than attributing it to third parties.

## What changed

- **`skills/data-discovery/SKILL.md`** — frontmatter `description:` no longer names the data provider; the agent's skill-router blurb now lists data by venue (Deribit/OKX/Bybit) and product (Bullish, IBIT) without provider attribution. In-body section "Tardis Market Data" renamed to "Exchange Market Data". Catalog prose, trigger phrases, partition-pattern labels, query guidelines, and the "What is NOT here" caveats all neutralized.
- **`skills/data-discovery/references/datasets.md`** — Dataset 2 header "Deribit & OKX Options via Tardis" → "Deribit & OKX Options". Removed "Raw exchange market data sourced from Tardis" and "Unlike Tardis" framing. `local_timestamp` column note "Tardis receipt timestamp" → "Receipt timestamp" everywhere. Cross-dataset notes about timestamp units, partitions, and joins re-phrased generically. IBIT description no longer attributes to BlackRock.
- **`skills/data-discovery/evals/evals.json`** — expected outputs and trigger queries no longer use "Tardis" as a keyword (e.g. `"do we have OKX combo quotes in the Tardis bucket"` → `"… in the S3 bucket"`).
- **`skills/block-analyst/references/rfq-lookup.md`** — historical greeks/IV fallback path now reads "Bullish chain snapshots / exchange market data" instead of "Bullish chain snapshots / Tardis".
- **`skills/block-analyst/references/venues.md`** — IBIT description drops the BlackRock attribution.

Net diff: **5 files, +48 / −46**.

## What did NOT change (intentional)

- **Literal S3 paths** like `s3://terminal-dime-prod/external/tardis/v1/...` are kept as-is. The actual S3 layout still uses that prefix, and changing the docs without an infra-side rename would yield DuckDB queries that 404. **Follow-up:** an infra PR to copy/replicate to a neutral prefix (e.g. `external/v1/`) and update these doc paths to match.
- **Venue and product names** (Deribit, OKX, Bybit, Bullish, IBIT) are retained. They describe *what* the data is about (the market or instrument), not *who* supplied it — removing them would gut the skill's catalog utility.
- **Self-improving-agent `.learnings/`** captured on the EBS PVC across customer pods. Any prior session that learned "the data is from <provider>" persists there independently of this branch. A separate cleanup (or wipe of `~/.openclaw/workspace/.learnings/`) may be needed if old impressions leak through after redeploy.

## Why

So the dime terminal presents its catalog as Paradigm's own market data, with no language suggesting an external source or supplier.

## Deployment note

The openclaw pods `git clone` this repo on boot from `main` (see `mono/api/paradex/terminal/setup-openclaw-docker.sh:79-84`). After merge, each customer StatefulSet needs a `kubectl rollout restart` to re-clone — the in-flight pods will keep serving the old SKILL.md until restarted.